### PR TITLE
Fix unmanaged models showing up as a related field

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,8 +6,8 @@ steps:
     agents:
       queue: builders
     plugins:
-      docker-compose#v1.6.0:
-        build: django_super_deduper
+      docker-compose#v3.0.2:
+        build: django-super-deduper
         config:
           - docker-compose.yml
         image-repository: "$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY"
@@ -20,32 +20,32 @@ steps:
     agents:
       queue: pytest
     plugins:
-      docker-compose#v1.6.0:
-        run: app
+      docker-compose#v3.0.2:
+        run: django-super-deduper
         config:
           - docker-compose.yml
 
   - name: "mypy"
     command: mypy django_super_deduper/
     plugins:
-      docker-compose#v1.6.0:
-        run: app
+      docker-compose#v3.0.2:
+        run: django-super-deduper
         config:
             - docker-compose.yml
 
   - name: "isort"
     command: isort --check-only
     plugins:
-      docker-compose#v1.6.0:
-        run: app
+      docker-compose#v3.0.2:
+        run: django-super-deduper
         config:
           - docker-compose.yml
 
   - name: "flake8"
     command: flake8
     plugins:
-      docker-compose#v1.6.0:
-        run: app
+      docker-compose#v3.0.2:
+        run: django-super-deduper
         config:
           - docker-compose.yml
 

--- a/django_super_deduper/models.py
+++ b/django_super_deduper/models.py
@@ -10,7 +10,7 @@ class ModelMeta(object):
 
     @staticmethod
     def is_related_field(field: Field):
-        return field.one_to_many or field.one_to_one or field.many_to_many and field.related_model._meta.managed
+        return (field.one_to_many or field.one_to_one or field.many_to_many) and field.related_model._meta.managed
 
     @property
     def related_fields(self) -> List[Field]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "2.1"
 services:
-  app:
+  django-super-deduper:
     build:
       context: .
     volumes:

--- a/tests/models.py
+++ b/tests/models.py
@@ -45,6 +45,13 @@ class EarningsReport(models.Model):
         return f'{self.restaurant}, {self.date}: {self.amount}'
 
 
+class MaterializedReport(models.Model):
+    restaurant = models.ForeignKey(Restaurant, on_delete=models.DO_NOTHING)
+
+    class Meta:
+        managed = False
+
+
 class NewsAgency(Place):
     website = models.CharField(max_length=50, null=True)
 

--- a/tests/test_super_deduper.py
+++ b/tests/test_super_deduper.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django_super_deduper.merge import MergedModelInstance
+from django_super_deduper.models import ModelMeta
 from tests.factories import (
     ArticleFactory,
     EarningsReportFactory,
@@ -184,3 +185,15 @@ class MergedModelInstanceTest(object):
         _, audit_trail = MergedModelInstance.create_with_audit_trail(primary_object, [alias_object])
 
         assert set(audit_trail) == related_objects
+
+
+@pytest.mark.django_db
+class ModelMetaTest(object):
+
+    def test_unmanaged_related_fields(self):
+        instance = RestaurantFactory()
+
+        model_meta = ModelMeta(instance)
+
+        for field in model_meta.related_fields:
+            assert field.related_model._meta.managed


### PR DESCRIPTION
This fixes a bug when checking for a model's related fields, causing unmanaged models to show up as valid merge-able fields.

Fixes https://github.com/mighty-justice/django-super-deduper/issues/11