### PR TITLE
Fix audit trail for deleted objects

### DIFF
--- a/django_super_deduper/merge.py
+++ b/django_super_deduper/merge.py
@@ -71,7 +71,9 @@ class MergedModelInstance(object):
                     obj.save()
                 else:
                     logger.debug(f'Deleting {obj._meta.model.__name__}[pk={obj.pk}]')
+                    _pk = obj.pk
                     obj.delete()
+                    obj.pk = _pk  # pk is cached and re-assigned to keep the audit trail in tact
             self.modified_related_objects.append(obj)
 
     def _handle_m2m_related_field(self, related_field: Field, alias_object: Model):


### PR DESCRIPTION
When an object is deleted we lose reference to it's PK, which
makes keeping track of that object in the audit trail useless.

This fix makes sure we always have the PK, even if the object is deleted.