### PR TITLE
Support merging generic related fields

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
   - wait
 
   - name: "pytest"
-    command: pytest --cov=./ --cov-report=xml:coverage.xml
+    command: pytest --cov=./django_super_deduper --cov-report=xml:coverage.xml
     artifact_paths: "coverage.xml"
     agents:
       queue: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def pytest_configure():
             }
         },
         INSTALLED_APPS=(
+            'django.contrib.contenttypes',
             'tests',
         ),
         LOGGING={

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 
@@ -19,7 +21,7 @@ class Restaurant(models.Model):
     serves_pizza = models.BooleanField(default=False)
 
     def __str__(self):
-        return f'{self.place}'
+        return self.place
 
 
 class Waiter(models.Model):
@@ -27,7 +29,7 @@ class Waiter(models.Model):
     restaurant = models.ForeignKey(Restaurant, null=True, on_delete=models.SET_NULL)
 
     def __str__(self):
-        return f'{self.name}'
+        return self.name
 
     class Meta:
         unique_together = ('name', 'restaurant', )
@@ -81,6 +83,17 @@ class Article(models.Model):
     pub_date = models.DateField(auto_now_add=True)
     publications = models.ManyToManyField(Publication)
     reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE, null=True)
+    tags = GenericRelation('TaggedItem')
 
     def __str__(self):
-        return f'{self.headline}'
+        return self.headline
+
+
+class TaggedItem(models.Model):
+    tag = models.SlugField()
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey('content_type', 'object_id')
+
+    def __str__(self):
+        return self.tag

--- a/tests/test_super_deduper.py
+++ b/tests/test_super_deduper.py
@@ -196,6 +196,16 @@ class MergedModelInstanceTest(object):
 
         assert set(audit_trail) == related_objects
 
+    def test_merge_generic_foreign_keys(self):
+        primary_object = ArticleFactory()
+        alias_object = ArticleFactory()
+        primary_object.tags.create(content_object=primary_object, tag='django')
+        alias_object.tags.create(content_object=alias_object, tag='python')
+
+        merged_object = MergedModelInstance.create(primary_object, [alias_object], keep_old=False)
+
+        assert merged_object.tags.count() == 2
+
 
 @pytest.mark.django_db
 class ModelMetaTest(object):


### PR DESCRIPTION
Had to dig into the [Django generic foreign relation internals](https://github.com/django/django/blob/9624703a06187060c1a494e533f3e27fed946de3/django/contrib/contenttypes/fields.py#L332) to figure out how to pull out the name of the related generic foreign key field.

Closes https://github.com/mighty-justice/django-super-deduper/issues/5
Closes https://github.com/mighty-justice/django-super-deduper/pull/6